### PR TITLE
Add basic nix env to compile the project

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,14 @@
+# Compile with nix
+
+The [nix](https://nixos.org/download.html) allows to setup deterministic environment for external dependencies on any Linux distributive.
+
+Run this in the `contrib` folder to enter the env:
+```
+nix-shell
+```
+
+Next you can build the project as usual:
+```
+cd ..
+cargo run --release --bin mycitadel
+```

--- a/contrib/shell.nix
+++ b/contrib/shell.nix
@@ -1,0 +1,44 @@
+with import ((import <nixpkgs> {}).fetchFromGitHub {
+  owner = "NixOS";
+  repo = "nixpkgs-channels";
+  rev = "4762fba469e2baa82f983b262e2c06ac2fdaae67";
+  sha256  = "1sidky93vc2bpnwb8avqlym1p70h2szhkfiam549377v9r5ld2r1";
+}) {};
+let merged-openssl = symlinkJoin { name = "merged-openssl"; paths = [ openssl.out openssl.dev ]; };
+in stdenv.mkDerivation rec {
+  name = "rust-env";
+  env = buildEnv { name = name; paths = buildInputs; };
+
+  buildInputs = [
+    rustup
+    clang
+    llvm
+    llvmPackages.libclang
+    openssl
+    cacert
+    glib
+    atk
+    gtk3
+    pango
+    cairo
+    harfbuzz
+    gdk-pixbuf
+  ];
+  shellHook = let
+   pkg-config-path = lib.concatMapStringsSep ":" (pkg: "${pkg.dev}/lib/pkgconfig") [
+     cairo
+     pango
+     glib
+     atk
+     gtk3
+     gdk-pixbuf
+     harfbuzz
+     librsvg
+   ]; 
+  in ''
+  export LIBCLANG_PATH="${llvmPackages.libclang}/lib"
+  export OPENSSL_DIR="${merged-openssl}"
+  export PKG_CONFIG_PATH="${pkg-config-path}:$PKG_CONFIG_PATH"
+  export GDK_PIXBUF_MODULE_FILE=${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+  '';
+}


### PR DESCRIPTION
Fix #32

Note that the script is designed only to provide rustup and all system deps into the scope. Usually there are some more scripts that allows to deterministically build whole package, but they are more complex for rust than that I provided in the PR. 